### PR TITLE
Add "fixie query" CLI command. (#114)

### DIFF
--- a/fixieai/cli/cli.py
+++ b/fixieai/cli/cli.py
@@ -51,6 +51,7 @@ fixie.add_command(agent_commands.serve, "serve")
 fixie.add_command(agent_commands.publish, "publish")
 fixie.add_command(agent_commands.unpublish, "unpublish")
 fixie.add_command(session_commands.new_session, "console")
+fixie.add_command(session_commands.query, "query")
 
 
 if __name__ == "__main__":

--- a/fixieai/cli/session/commands.py
+++ b/fixieai/cli/session/commands.py
@@ -1,5 +1,8 @@
+from typing import Optional
+
 import click
 
+from fixieai import FixieClient
 from fixieai.cli.session import console
 
 
@@ -34,6 +37,68 @@ def web_option(func):
     )(func)
 
 
+def run_session(
+    client: FixieClient,
+    session_id: Optional[str] = None,
+    agent: Optional[str] = None,
+    message: Optional[str] = None,
+    use_console: bool = False,
+    web: bool = False,
+    keep: bool = False,
+    verbose: bool = False,
+):
+    """Runs a session.
+
+    Args:
+        client: The FixieClient instance.
+        session_id: The ID of the session to use. If not provided, a new session is created.
+        agent: The agent to use for the session.
+        message: The message to send to the session.
+        use_console: Whether to run the session in the console.
+        web: Whether to open the session in the web interface.
+        keep: Whether to keep the session after it is finished.
+        verbose: Whether to print verbose output.
+    """
+    if session_id is not None:
+        session = client.get_session(session_id)
+    else:
+        session = client.create_session(agent)
+    if verbose:
+        click.secho(f"Session ID: ", nl=False)
+        click.secho(f"{session.session_id}", fg="green")
+        click.secho(f"Session URL: ", nl=False)
+        click.secho(f"{session.session_url}", fg="green")
+
+    if web:
+        click.launch(session.session_url)
+        return
+    if use_console:
+        c = console.Console(client, session=session)
+        c.run(message)
+    else:
+        if message:
+            response = session.query(message)
+            print(response)
+        if web:
+            if keep:
+                click.secho(
+                    "Warning: --keep is ignored when --web is specified.",
+                    fg="yellow",
+                )
+            click.launch(session.session_url)
+            return
+        elif not message:
+            raise click.BadParameter(
+                "You must specify either --console, --web, or a query message"
+            )
+
+    if not keep:
+        if verbose:
+            click.echo(f"Deleting session ", nl=False)
+            click.secho(f"{session.session_id}", fg="green")
+        session.delete_session()
+
+
 @session.command("new", help="Creates a new session and opens it.")
 @click.argument("message", required=False)
 @web_option
@@ -44,28 +109,56 @@ def web_option(func):
     callback=validate_agent_exists,
     help="A specific agent to talk to. If unset, `fixie` is used.",
 )
+@click.option("-v", "--verbose", is_flag=True, help="Enable verbose output.")
 @click.pass_context
-def new_session(ctx, agent, web, message):
-    client = ctx.obj.client
-    session = client.create_session(agent)
-    if web:
-        click.launch(session.session_url)
-        return
-
-    c = console.Console(client, session=session)
-    c.run(message)
+def new_session(ctx, agent, web, message, verbose):
+    run_session(ctx.obj.client, agent=agent, message=message, web=web, use_console=True)
 
 
 @session.command("open", help="Opens a session.")
-@click.argument("session_id")
+@click.argument("session_id", required=True)
+@click.argument("message", required=False)
 @web_option
+@click.option(
+    "-a",
+    "--agent",
+    required=False,
+    callback=validate_agent_exists,
+    help="A specific agent to talk to. If unset, `fixie` is used.",
+)
+@click.option("-v", "--verbose", is_flag=True, help="Enable verbose output.")
 @click.pass_context
-def open_session(ctx, web, session_id: str):
-    client = ctx.obj.client
-    session = client.get_session(session_id)
-    if web:
-        click.launch(session.session_url)
-        return
+def open_session(ctx, session_id: str, web, agent, message, verbose):
+    run_session(
+        ctx.obj.client,
+        session_id=session_id,
+        agent=agent,
+        message=message,
+        web=web,
+        use_console=True,
+    )
 
-    c = console.Console(client, session=session)
-    c.run()
+
+@session.command("query", help="Runs a single query and exit.")
+@click.argument("message", required=True)
+@web_option
+@click.option("--keep", is_flag=True, help="Do not delete the session after use.")
+@click.option("-v", "--verbose", is_flag=True, help="Enable verbose output.")
+@click.option(
+    "-a",
+    "--agent",
+    required=False,
+    callback=validate_agent_exists,
+    help="A specific agent to talk to. If unset, `fixie` is used.",
+)
+@click.pass_context
+def query(ctx, agent, web, keep, verbose, message):
+    run_session(
+        ctx.obj.client,
+        agent=agent,
+        message=message,
+        web=web,
+        keep=keep,
+        verbose=verbose,
+        use_console=False,
+    )


### PR DESCRIPTION
This is useful for doing a one-off query in an ephemeral session. I plan to use this in the GitHub Actions run for deploying agents from the fixie-examples repo, to send off a quick query to each deployed agent to make sure it is working correctly.